### PR TITLE
Use unsafe calls to c

### DIFF
--- a/System/Endian.hs
+++ b/System/Endian.hs
@@ -86,5 +86,5 @@ swap32 = fromIntegral . c_swap32 . fromIntegral
 swap64 :: Word64 -> Word64
 swap64 = fromIntegral . c_swap64 . fromIntegral
 
-foreign import ccall safe "bitfn_swap32" c_swap32 :: CUInt -> CUInt
-foreign import ccall safe "bitfn_swap64" c_swap64 :: CULLong -> CULLong
+foreign import ccall unsafe "bitfn_swap32" c_swap32 :: CUInt -> CUInt
+foreign import ccall unsafe "bitfn_swap64" c_swap64 :: CULLong -> CULLong


### PR DESCRIPTION
There is substantial overhead involved with a safe call, that's easily much greater than the computation actually performed here.   And given that your helpers operate in a small constant time,  I don't see why you need a safe call.
