### PR TITLE
Added cbits and System.Endian fns for Word16

### DIFF
--- a/System/Endian.hs
+++ b/System/Endian.hs
@@ -12,13 +12,17 @@ module System.Endian
     -- little endian to and from cpu
     , fromLE32
     , fromLE64
+    , fromLE16
     , toLE32
     , toLE64
+    , toLE16
     -- big endian to and from cpu
     , fromBE32
     , fromBE64
+    , fromBE16
     , toBE32
     , toBE64
+    , toBE16
     ) where
 
 #include "MachDeps.h"
@@ -60,6 +64,15 @@ fromBE32 = if getSystemEndianness == BigEndian then id else swap32
 fromLE32 :: Word32 -> Word32
 fromLE32 = if getSystemEndianness == LittleEndian then id else swap32
 
+-- | Convert from a big endian 16 bit value to the cpu endianness
+fromBE16 :: Word16 -> Word16
+fromBE16 = if getSystemEndianness == BigEndian then id else swap16
+
+-- | Convert from a little endian 16 bit value to the cpu endianness
+fromLE16 :: Word16 -> Word16
+fromLE16 = if getSystemEndianness == LittleEndian then id else swap16
+
+
 -- | Convert a 64 bit value in cpu endianess to big endian
 toBE64 :: Word64 -> Word64
 toBE64 = fromBE64
@@ -76,8 +89,20 @@ toBE32 = fromBE32
 toLE32 :: Word32 -> Word32
 toLE32 = fromLE32
 
+-- | Convert a 16 bit value in cpu endianness to big endian
+toBE16 :: Word16 -> Word16
+toBE16 = fromBE16
+
+-- | Convert a 16 bit value in cpu endianness to little endian
+toLE16 :: Word16 -> Word16
+toLE16 = fromLE16
+
 #if MIN_VERSION_base(4,7,0)
 
+-- | Transform a 16 bit value bytes from a.b to b.a
+swap16 :: Word16 -> Word16
+swap16 = byteSwap16
+    
 -- | Transform a 32 bit value bytes from a.b.c.d to d.c.b.a
 swap32 :: Word32 -> Word32
 swap32 = byteSwap32
@@ -87,6 +112,11 @@ swap64 :: Word64 -> Word64
 swap64 = byteSwap64
 
 #else
+
+-- | Transform a 16 bit value bytes from a.b to b.a
+{-# INLINE swap16 #-}
+swap16 :: Word16 -> Word16
+swap16 = fromIntegral . c_swap16 . fromIntegral
 
 -- | Transform a 32 bit value bytes from a.b.c.d to d.c.b.a
 {-# INLINE swap32 #-}
@@ -98,7 +128,10 @@ swap32 = fromIntegral . c_swap32 . fromIntegral
 swap64 :: Word64 -> Word64
 swap64 = fromIntegral . c_swap64 . fromIntegral
 
+foreign import ccall unsafe "bitfn_swap16" c_swap16 :: CUShort -> CUShort
 foreign import ccall unsafe "bitfn_swap32" c_swap32 :: CUInt -> CUInt
 foreign import ccall unsafe "bitfn_swap64" c_swap64 :: CULLong -> CULLong
 
 #endif
+
+

--- a/cbits/endian.c
+++ b/cbits/endian.c
@@ -52,3 +52,8 @@ uint64_t bitfn_swap64(uint64_t a)
 	        (((uint64_t) bitfn_swap32((uint32_t) a)) << 32);
 }
 #endif
+
+uint16_t bitfn_swap16(uint16_t a)
+{
+  return (a << 8) | (a >> 8);
+}


### PR DESCRIPTION
After an interesting but fruitless two day exploration of assembly language (trying to copy your style for bitfn_swap64), I went with c for bitfn_swap16.

I did quick tests with both the base-4.7.0 code and the pre base-4.7.0 code, but I would appreciate if you could give the additions a quick check in case I messed up.  Thanks!
